### PR TITLE
PHP 8.1 compatibility

### DIFF
--- a/src/backends/ts_backend.php
+++ b/src/backends/ts_backend.php
@@ -562,6 +562,7 @@ class ezcTranslationTsBackend implements ezcTranslationBackend, ezcTranslationCo
      *         not initialized with initReader().
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function next()
     {
         if ( is_null( $this->xmlParser ) )
@@ -604,6 +605,7 @@ class ezcTranslationTsBackend implements ezcTranslationBackend, ezcTranslationCo
      *         not initialized with initReader().
      * @return bool
      */
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return $this->currentContext != null;
@@ -644,6 +646,7 @@ class ezcTranslationTsBackend implements ezcTranslationBackend, ezcTranslationCo
      *         not initialized with initReader().
      * @return array The current context's translation map
      */
+    #[\ReturnTypeWillChange]
     public function current()
     {
         $context = $this->currentContext();
@@ -663,6 +666,7 @@ class ezcTranslationTsBackend implements ezcTranslationBackend, ezcTranslationCo
      *         not initialized with initReader().
      * @return string The current context's name
      */
+    #[\ReturnTypeWillChange]
     public function key()
     {
         $context = $this->currentContext();
@@ -683,6 +687,7 @@ class ezcTranslationTsBackend implements ezcTranslationBackend, ezcTranslationCo
      *         not initialized with initReader().
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function rewind()
     {
         $this->next();


### PR DESCRIPTION
added `#[\ReturnTypeWillChange]` to various methods to allow code running under php 8.1